### PR TITLE
Fix namespace collision for "ajax_object"

### DIFF
--- a/admin/class-descope-wp-admin.php
+++ b/admin/class-descope-wp-admin.php
@@ -78,7 +78,7 @@ class Descope_Wp_Admin
     {
 
         wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/descope-wp-admin.js', array('jquery'), $this->version, false);
-        wp_localize_script($this->plugin_name, 'my_ajax_object', array('ajax_url' => admin_url('admin-ajax.php'), 'security' => wp_create_nonce('sync_user_nonce')));
+        wp_localize_script($this->plugin_name, 'descope_admin_ajax_object', array('ajax_url' => admin_url('admin-ajax.php'), 'security' => wp_create_nonce('sync_user_nonce')));
     }
 
     public function create_descope_log_directory()

--- a/admin/js/descope-wp-admin.js
+++ b/admin/js/descope-wp-admin.js
@@ -33,12 +33,12 @@
             $('#progress-container').show();
 
             $.ajax({
-                url: my_ajax_object.ajax_url,
+                url: descope_admin_ajax_object.ajax_url,
                 type: 'POST',
                 data: {
                     action: 'sync_users_to_descope',
                     user_role: selectedRole,
-                    security: my_ajax_object.security
+                    security: descope_admin_ajax_object.security
                 },
                 success: function (response) {
                     if (response.success) {
@@ -75,11 +75,11 @@
             e.preventDefault();
 
             $.ajax({
-                url: my_ajax_object.ajax_url,
+                url: descope_admin_ajax_object.ajax_url,
                 type: 'POST',
                 data: {
                     action: 'clear_log_file',
-                    security: my_ajax_object.security
+                    security: descope_admin_ajax_object.security
                 },
                 success: function (response) {
                     if (response.success) {

--- a/public/class-descope-wp-public.php
+++ b/public/class-descope-wp-public.php
@@ -88,7 +88,7 @@ class Descope_Wp_Public
         wp_enqueue_script('descope-web-js', 'https://unpkg.com/@descope/web-js-sdk@latest/dist/index.umd.js', array('jquery'), $this->version, false);
         wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/descope-wp-public.js', array('jquery'), $this->version, false);
 
-        wp_localize_script($this->plugin_name, 'ajax_object', array(
+        wp_localize_script($this->plugin_name, 'descope_ajax_object', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('custom_nonce'),
             'siteUrl' => get_site_url(),

--- a/public/js/descope-wp-public.js
+++ b/public/js/descope-wp-public.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function () {
-    const projectId = ajax_object.clientId;
+    const projectId = descope_ajax_object.clientId;
     // get flow Id from shortcode & default to sign up or in if not present
-    const flowId = ajax_object.flowId ? ajax_object.flowId : 'sign-up-or-in';
+    const flowId = descope_ajax_object.flowId ? descope_ajax_object.flowId : 'sign-up-or-in';
     const sdk = Descope({
         projectId: projectId,
         persistTokens: true,
@@ -17,13 +17,13 @@ jQuery(document).ready(function () {
         }
 
         jQuery.ajax({
-            url: ajax_object.ajax_url,
+            url: descope_ajax_object.ajax_url,
             type: 'POST',
             data: {
                 action: 'create_wp_user',
                 sessionToken: sessionToken,
                 userDetails: JSON.stringify(userDetails),
-                nonce: ajax_object.nonce
+                nonce: descope_ajax_object.nonce
             },
             success: function (response) {
                 console.log(response);
@@ -78,7 +78,7 @@ jQuery(document).ready(function () {
     jQuery(".logoutButton").click(function () {
         logout().then((resp) => {
             // Redirect back to home page
-            window.location = ajax_object.siteUrl;
+            window.location = descope_ajax_object.siteUrl;
         });
 
         async function logout() {


### PR DESCRIPTION
Fixing use of 'ajax_object' and 'my_ajax_object' since it is too generic and runs into namespacing errors by other plugins that use the same variable names.

**This has not been fully tested, just enough to un-break other plugins. Please test before merging.**

## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

A few sentences describing the overall goals of the pull request's commits.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
