### PR TITLE
Fixing Logout for OIDC

### DIFF
--- a/public/class-descope-wp-public.php
+++ b/public/class-descope-wp-public.php
@@ -74,6 +74,7 @@ class Descope_Wp_Public
         add_action('init', array($this, 'descope_init_sso'));
 
         add_action('init', array($this, 'register_shortcodes'));
+        add_action('wp_logout', array($this, 'descope_end_session'));
     }
 
     public function enqueue_styles()
@@ -114,7 +115,12 @@ class Descope_Wp_Public
     // Destroy PHP session on logout
     public function descope_end_session()
     {
-        session_destroy();
+        session_destroy();        
+        // Delete the secure "DSR" cookie
+        if (isset($_COOKIE['DSR'])) {
+            unset($_COOKIE['DSR']);            
+        }        
+        setcookie('DSR', '', time() - 3600, '/', parse_url(site_url( '', null), PHP_URL_HOST));
 
         // $this->auth->processSLO(false, $_SESSION['samlUserdata']);
         ?>

--- a/public/js/descope-wp-public.js
+++ b/public/js/descope-wp-public.js
@@ -48,9 +48,12 @@ jQuery(document).ready(function () {
 
     const refreshToken = sdk.getRefreshToken();
     const validRefreshToken = refreshToken && !sdk.isJwtExpired(refreshToken);
+    const container = document.getElementById("descope-flow-container");
 
-    if (!validRefreshToken) {
-        const container = document.getElementById("descope-flow-container");
+    //If validRefreshToken is false, and container exists on the page add this code
+    //   When user only uses [oidc_login_form] shortcode but does not use [descope_wc], the #descope-flow-container is never added to the page and script
+    //   Errors out before adding the .logoutButton.click() listener, breaking the link
+    if (!validRefreshToken &&  container != null) {        
         container.innerHTML = `<descope-wc style="outline: none;" project-id=${projectId} flow-id=${flowId} ></descope-wc>`;
         const wcElement = document.getElementsByTagName('descope-wc')[0];
 
@@ -68,7 +71,7 @@ jQuery(document).ready(function () {
     }
 
     // Add logout functionality
-    jQuery(".logoutButton").click(function (event) {
+    jQuery(".logoutButton").click(function (event) {        
         logout().then((resp) => {
             // After descope logout process completes, redirect to the wordpress logout url
             window.location = descope_ajax_object.logoutUrl;


### PR DESCRIPTION
## Related Issues

Fixes descope_end_session() never being called during logout session

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Fixes DSR cookie not being deleted on session Logout, this allow user to assume previous user's session by clicking "Login" again.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
