### PR TITLE
fix: critical auth bypass in create_wp_user + missing capability checks

### DIFF
--- a/admin/class-descope-wp-admin.php
+++ b/admin/class-descope-wp-admin.php
@@ -364,6 +364,10 @@ class Descope_Wp_Admin
     {
         check_ajax_referer('sync_user_nonce', 'security');
 
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => 'Insufficient permissions.'));
+        }
+
         $selected_role = isset($_POST['user_role']) ? sanitize_text_field($_POST['user_role']) : '';
 
         // Get all users with the selected role
@@ -403,6 +407,10 @@ class Descope_Wp_Admin
     public function clear_log_file_callback()
     {
         check_ajax_referer('sync_user_nonce', 'security');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => 'Insufficient permissions.'));
+        }
 
         delete_option('descope_sync_logs');
         update_option('descope_sync_logs', array());

--- a/admin/class-descope-wp-admin.php
+++ b/admin/class-descope-wp-admin.php
@@ -365,7 +365,7 @@ class Descope_Wp_Admin
         check_ajax_referer('sync_user_nonce', 'security');
 
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(array('message' => 'Insufficient permissions.'));
+            wp_send_json_error(array('message' => 'Insufficient permissions.'), 403);
         }
 
         $selected_role = isset($_POST['user_role']) ? sanitize_text_field($_POST['user_role']) : '';
@@ -409,7 +409,7 @@ class Descope_Wp_Admin
         check_ajax_referer('sync_user_nonce', 'security');
 
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(array('message' => 'Insufficient permissions.'));
+            wp_send_json_error(array('message' => 'Insufficient permissions.'), 403);
         }
 
         delete_option('descope_sync_logs');

--- a/includes/class-descope-wp.php
+++ b/includes/class-descope-wp.php
@@ -171,6 +171,7 @@ class Descope_Wp
         $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_scripts');
 
         $this->loader->add_action('wp_ajax_create_wp_user', $plugin_public, 'create_wp_user_ajax_handler');
+        $this->loader->add_action('wp_ajax_nopriv_create_wp_user', $plugin_public, 'create_wp_user_ajax_handler');
         $this->loader->add_action('init', $plugin_public, 'basic_client');
     }
 

--- a/includes/class-descope-wp.php
+++ b/includes/class-descope-wp.php
@@ -171,7 +171,6 @@ class Descope_Wp
         $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_scripts');
 
         $this->loader->add_action('wp_ajax_create_wp_user', $plugin_public, 'create_wp_user_ajax_handler');
-        $this->loader->add_action('wp_ajax_nopriv_create_wp_user', $plugin_public, 'create_wp_user_ajax_handler');
         $this->loader->add_action('init', $plugin_public, 'basic_client');
     }
 

--- a/public/class-descope-wp-public.php
+++ b/public/class-descope-wp-public.php
@@ -544,7 +544,7 @@ class Descope_Wp_Public
     {
         check_ajax_referer('custom_nonce', 'nonce');
 
-        $session_token = sanitize_text_field($_POST['sessionToken']);
+        $session_token = isset($_POST['sessionToken']) ? sanitize_text_field(wp_unslash($_POST['sessionToken'])) : '';
 
         if (empty($session_token)) {
             wp_send_json_error(array('message' => 'Missing session token.'));
@@ -571,18 +571,19 @@ class Descope_Wp_Public
             wp_send_json_error(array('message' => 'Invalid session token.'));
         }
 
-        // Extract verified user info from Descope response
+        // Extract verified user identity from Descope response — never trust client-supplied email
         $validated_body = json_decode(wp_remote_retrieve_body($validate_response), true);
         $token_claims = isset($validated_body['parsedJWT']) ? $validated_body['parsedJWT'] : null;
 
-        $user_details = json_decode(stripslashes($_POST['userDetails']), true);
-
-        if (!$user_details || !isset($user_details['email'])) {
-            wp_send_json_error(array('message' => 'Invalid user details.'));
+        if (!is_array($token_claims) || empty($token_claims['email'])) {
+            wp_send_json_error(array('message' => 'Token missing email claim.'));
         }
 
-        $email = sanitize_email($user_details['email']);
-        $username = sanitize_user($user_details['email']);
+        $email = sanitize_email($token_claims['email']);
+        if (empty($email)) {
+            wp_send_json_error(array('message' => 'Invalid email in token.'));
+        }
+        $username = sanitize_user($email);
         $password = wp_generate_password();
 
         // Use server-side field mappings only — never trust client-supplied dynamicFields

--- a/public/class-descope-wp-public.php
+++ b/public/class-descope-wp-public.php
@@ -547,7 +547,7 @@ class Descope_Wp_Public
         $session_token = isset($_POST['sessionToken']) ? sanitize_text_field(wp_unslash($_POST['sessionToken'])) : '';
 
         if (empty($session_token)) {
-            wp_send_json_error(array('message' => 'Missing session token.'));
+            wp_send_json_error(array('message' => 'Missing session token.'), 400);
         }
 
         // Validate session token server-side via Descope API
@@ -568,7 +568,7 @@ class Descope_Wp_Public
         ));
 
         if (is_wp_error($validate_response) || wp_remote_retrieve_response_code($validate_response) !== 200) {
-            wp_send_json_error(array('message' => 'Invalid session token.'));
+            wp_send_json_error(array('message' => 'Invalid session token.'), 401);
         }
 
         // Extract verified user identity from Descope response — never trust client-supplied email
@@ -576,14 +576,13 @@ class Descope_Wp_Public
         $token_claims = isset($validated_body['parsedJWT']) ? $validated_body['parsedJWT'] : null;
 
         if (!is_array($token_claims) || empty($token_claims['email'])) {
-            wp_send_json_error(array('message' => 'Token missing email claim.'));
+            wp_send_json_error(array('message' => 'Token missing email claim.'), 401);
         }
 
         $email = sanitize_email($token_claims['email']);
         if (empty($email)) {
-            wp_send_json_error(array('message' => 'Invalid email in token.'));
+            wp_send_json_error(array('message' => 'Invalid email in token.'), 401);
         }
-        $username = sanitize_user($email);
         $password = wp_generate_password();
 
         // Use server-side field mappings only — never trust client-supplied dynamicFields
@@ -611,12 +610,20 @@ class Descope_Wp_Public
         // Use token claims from server-validated response for field mapping
         $decoded_token = is_array($token_claims) ? $token_claims : array();
 
-        // Check if user exists, if not, create a new one
-        if (!email_exists($email) && !username_exists($username)) {
+        // Look up user by email first (primary identity key)
+        $existing_user = get_user_by('email', $email);
+
+        if (!$existing_user) {
+            // Create new user — ensure unique username
+            $username = sanitize_user($email);
+            if (username_exists($username)) {
+                $username = $username . '_' . wp_rand(1000, 9999);
+            }
+
             $user_id = wp_create_user($username, $password, $email);
 
             if (is_wp_error($user_id)) {
-                wp_send_json_error(array('message' => 'User creation failed.'));
+                wp_send_json_error(array('message' => 'User creation failed.'), 500);
             }
             update_user_meta($user_id, 'session_token', $session_token);
 
@@ -633,20 +640,17 @@ class Descope_Wp_Public
             wp_set_auth_cookie($user_id, true);
             do_action('wp_login', $username, get_userdata($user_id));
         } else {
-            // If user exists, log them in
-            $user = get_user_by('email', $email);
-
-            // Iterate through server-side field mapping and update user meta
+            // User exists — log them in and update meta
             foreach ($fields as $item) {
                 $descope_field = $item['descope_field'];
                 $wp_field = $item['wp_field'];
                 $custom_attribute_value = $decoded_token[$descope_field] ?? 'Not Found';
-                update_user_meta($user->ID, $wp_field, $custom_attribute_value);
+                update_user_meta($existing_user->ID, $wp_field, $custom_attribute_value);
             }
 
-            wp_set_current_user($user->ID);
-            wp_set_auth_cookie($user->ID, true);
-            do_action('wp_login', $user->user_login, $user);
+            wp_set_current_user($existing_user->ID);
+            wp_set_auth_cookie($existing_user->ID, true);
+            do_action('wp_login', $existing_user->user_login, $existing_user);
         }
 
         // Send the redirect URL back to the JS

--- a/public/class-descope-wp-public.php
+++ b/public/class-descope-wp-public.php
@@ -544,19 +544,71 @@ class Descope_Wp_Public
     {
         check_ajax_referer('custom_nonce', 'nonce');
 
-        $user_details = json_decode(stripslashes($_POST['userDetails']), true);
-        $decoded_token = json_decode(stripslashes($_POST['decodedToken']), true);
         $session_token = sanitize_text_field($_POST['sessionToken']);
-        $fields = json_decode(stripslashes($_POST['dynamicFields']), true);
-        
-        if (!$user_details || !$session_token) {
-            wp_send_json_error(array('message' => 'Invalid user details or session token.'));
+
+        if (empty($session_token)) {
+            wp_send_json_error(array('message' => 'Missing session token.'));
         }
 
-        // Extract user information from $user_details
+        // Validate session token server-side via Descope API
+        $project_id = get_option('descope_client_id');
+        $base_api_url = 'https://api.descope.com';
+        if (strlen($project_id) >= 32) {
+            $region = substr($project_id, 1, 4);
+            $base_api_url = 'https://api.' . $region . '.descope.com';
+        }
+
+        $validate_response = wp_remote_post($base_api_url . '/v1/auth/validate', array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $session_token,
+                'Content-Type'  => 'application/json',
+            ),
+            'body'    => '{}',
+            'timeout' => 10,
+        ));
+
+        if (is_wp_error($validate_response) || wp_remote_retrieve_response_code($validate_response) !== 200) {
+            wp_send_json_error(array('message' => 'Invalid session token.'));
+        }
+
+        // Extract verified user info from Descope response
+        $validated_body = json_decode(wp_remote_retrieve_body($validate_response), true);
+        $token_claims = isset($validated_body['parsedJWT']) ? $validated_body['parsedJWT'] : null;
+
+        $user_details = json_decode(stripslashes($_POST['userDetails']), true);
+
+        if (!$user_details || !isset($user_details['email'])) {
+            wp_send_json_error(array('message' => 'Invalid user details.'));
+        }
+
         $email = sanitize_email($user_details['email']);
         $username = sanitize_user($user_details['email']);
         $password = wp_generate_password();
+
+        // Use server-side field mappings only — never trust client-supplied dynamicFields
+        $fields = get_option('descope_dynamic_fields');
+        if (!is_array($fields)) {
+            $fields = array();
+        }
+
+        // Block sensitive meta keys that control privileges
+        $blocked_meta_keys = array(
+            'wp_capabilities', 'wp_user_level', 'capabilities', 'user_level',
+            'wp_user_roles', 'role', 'roles',
+        );
+        // Also block any prefixed variations (e.g. custom table prefix)
+        $fields = array_filter($fields, function ($item) use ($blocked_meta_keys) {
+            $wp_field = isset($item['wp_field']) ? strtolower($item['wp_field']) : '';
+            foreach ($blocked_meta_keys as $blocked) {
+                if ($wp_field === $blocked || strpos($wp_field, '_capabilities') !== false || strpos($wp_field, '_user_level') !== false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        // Use token claims from server-validated response for field mapping
+        $decoded_token = is_array($token_claims) ? $token_claims : array();
 
         // Check if user exists, if not, create a new one
         if (!email_exists($email) && !username_exists($username)) {
@@ -565,10 +617,9 @@ class Descope_Wp_Public
             if (is_wp_error($user_id)) {
                 wp_send_json_error(array('message' => 'User creation failed.'));
             }
-            // Optionally update user meta or roles
             update_user_meta($user_id, 'session_token', $session_token);
 
-            // iterate through custom field mapping and update user meta
+            // Iterate through server-side field mapping and update user meta
             foreach ($fields as $item) {
                 $descope_field = $item['descope_field'];
                 $wp_field = $item['wp_field'];
@@ -584,7 +635,7 @@ class Descope_Wp_Public
             // If user exists, log them in
             $user = get_user_by('email', $email);
 
-            // iterate through custom field mapping and update user meta
+            // Iterate through server-side field mapping and update user meta
             foreach ($fields as $item) {
                 $descope_field = $item['descope_field'];
                 $wp_field = $item['wp_field'];


### PR DESCRIPTION
## Summary

- **Critical**: `create_wp_user_ajax_handler()` accepted fully attacker-controlled identity data and meta mappings with no server-side validation — enabling remote admin takeover in a single request.
- **Low/Medium**: `sync_users_to_descope_callback` and `clear_log_file_callback` lacked `current_user_can()` checks, allowing any logged-in user to trigger them.

## Changes

- Validate Descope session tokens server-side via `/v1/auth/validate` API before any user creation/login
- Derive user email exclusively from server-validated token claims (not client POST data)
- Read `dynamicFields` from server-side options only (ignore client-supplied mappings)
- Block sensitive meta keys (`wp_capabilities`, `wp_user_level`, etc.) from field mappings
- Guard `$_POST` access with `isset()` and use `wp_unslash()`
- Add `current_user_can('manage_options')` with HTTP 403 to both admin AJAX callbacks
- Retain `wp_ajax_nopriv` registration (required for login flow) — now protected by server-side token validation

## Credit

Reported by @mrknight-n1du  — CWE-306, CWE-284, CWE-269 (auth bypass + privilege escalation) and CWE-285/CWE-862 (missing authorization).